### PR TITLE
Feature/get bucket in source

### DIFF
--- a/buckets.go
+++ b/buckets.go
@@ -1,0 +1,67 @@
+package influxdb
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+func (c *Client) GetBucketsInSource(id string) (*BucketSource, error) {
+	log.Printf("[DEBUG] Get buckets from source with id %s ", id)
+
+	req, err := http.NewRequest(http.MethodGet, c.url.String()+"/sources/"+id+"/buckets", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Accept", "*/*")
+	req.Header.Add("Authorization", c.authorization)
+	resp, err := c.httpClient.Do(req)
+
+	defer resp.Body.Close()
+	bucketSource := &BucketSource{}
+	if err := json.NewDecoder(resp.Body).Decode(bucketSource); err != nil {
+		return nil, err
+	}
+
+	return bucketSource, nil
+}
+
+type BucketSource struct {
+	Links struct {
+		Next string `json:"next"`
+		Self string `json:"self"`
+		Prev string `json:"prev"`
+	} `json:"links"`
+	Buckets []struct {
+		Links struct {
+			Labels  string `json:"labels"`
+			Logs    string `json:"logs"`
+			Members string `json:"members"`
+			Org     string `json:"org"`
+			Owners  string `json:"owners"`
+			Self    string `json:"self"`
+			Write   string `json:"write"`
+		} `json:"links"`
+		Id             string `json:"id"`
+		Type           string `json:"type"`
+		Name           string `json:"name"`
+		Description    string `json:"description"`
+		OrgId          string `json:"orgId"`
+		Rp             string `json:"rp"`
+		CreatedAt      string `json:"createdAt"`
+		UpdatedAt      string `json:"updatedAt"`
+		RetentionRules []struct {
+			Type         string `json:"type"`
+			EverySeconds int    `json:"everySeconds"`
+		} `json:"retentionRules"`
+	} `json:"buckets"`
+	Labels []struct {
+		Id          string `json:"id"`
+		OrgId       string `json:"orgId"`
+		Name        string `json:"name"`
+		Properties  string `json:"properties"`
+		Color       string `json:"color"`
+		Description string `json:"description"`
+	} `json:"labels"`
+}

--- a/query.go
+++ b/query.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/influxdb-client-go/internal/ast"
+	"github.com/lancey-energy-storage/influxdb-client-go/internal/ast"
 )
 
 const (

--- a/write.go
+++ b/write.go
@@ -14,7 +14,7 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/influxdata/influxdb-client-go/internal/gzip"
+	"github.com/lancey-energy-storage/influxdb-client-go/internal/gzip"
 	lp "github.com/influxdata/line-protocol"
 )
 


### PR DESCRIPTION
The getBucketsInSource can get all sources linked to a source. To get these buckets, the client needs to submit the source id. The function returns a BucketSource object that fits the returned json from the Influxdbv2 API. This refers to this official [documentation](https://v2.docs.influxdata.com/v2.0/api/#operation/GetSourcesIDBuckets) link.