### PR TITLE
Added GetUrl() function to return url of instance

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,8 +111,5 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) GetUrl() (string, error) {
-	if c.url.String() == "" {
-		return "", nil
-	}
 	return c.url.String(), nil
 }

--- a/client.go
+++ b/client.go
@@ -109,3 +109,10 @@ func (c *Client) Close() error {
 	c.httpClient.CloseIdleConnections()
 	return nil // we do this, so it qualifies as a closer.
 }
+
+func (c *Client) GetUrl() (string, error) {
+	if c.url.String() != "" {
+		return c.url.String(), nil
+	}
+	return "", nil
+}

--- a/client.go
+++ b/client.go
@@ -111,8 +111,8 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) GetUrl() (string, error) {
-	if c.url.String() != "" {
-		return c.url.String(), nil
+	if c.url.String() == "" {
+		return "", nil
 	}
-	return "", nil
+	return c.url.String(), nil
 }


### PR DESCRIPTION
This function allows to get the `url` of the instance created. It will be used on the `influxdb-provider` as the `id` of the resource.